### PR TITLE
Mp4MuxingList should return Mp4Muxing

### DIFF
--- a/lib/bitmovin/encoding/encodings/muxings/mp4_muxing_list.rb
+++ b/lib/bitmovin/encoding/encodings/muxings/mp4_muxing_list.rb
@@ -1,5 +1,5 @@
 module Bitmovin::Encoding::Encodings::Muxings
   class Mp4MuxingList < Bitmovin::Encoding::Encodings::List
-    init "muxings/mp4", Bitmovin::Encoding::Encodings::Muxings::TsMuxing
+    init "muxings/mp4", Bitmovin::Encoding::Encodings::Muxings::Mp4Muxing
   end
 end


### PR DESCRIPTION
encoder.muxing.mp4.build erroneously returns a TsMuxing instance. 
This should return a Mp4Muxing instance