### PR TITLE
Fix race condition when using multiple encoding IDs and streams

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    bitmovin-ruby (0.4.0)
+    bitmovin-ruby (0.6.0)
       activesupport (>= 4.0.0)
       faraday (~> 0.11.0)
       faraday_middleware (~> 0.11.0)

--- a/lib/bitmovin/encoding/encodings/muxings/muxing_resource.rb
+++ b/lib/bitmovin/encoding/encodings/muxings/muxing_resource.rb
@@ -8,7 +8,7 @@ module Bitmovin::Encoding::Encodings::Muxings
       hsh = ActiveSupport::HashWithIndifferentAccess.new(underscore_hash(hash))
       @encoding_id = encoding_id
       muxing_type = self.class.name.demodulize.gsub(/(.*)Muxing/, '\1').downcase
-      self.class.init(File.join("/v1/encoding/encodings/", encoding_id, "muxings", muxing_type))
+      init_instance(File.join("/v1/encoding/encodings/", encoding_id, "muxings", muxing_type))
       super(hsh)
       @outputs = (hsh[:outputs] || []).map do |output|
         Bitmovin::Encoding::StreamOutput.new(output)

--- a/lib/bitmovin/encoding/encodings/stream.rb
+++ b/lib/bitmovin/encoding/encodings/stream.rb
@@ -9,7 +9,7 @@ module Bitmovin::Encoding::Encodings
       set_defaults
       hsh = ActiveSupport::HashWithIndifferentAccess.new(underscore_hash(hash))
       @encoding_id = encoding_id
-      self.class.init(File.join("/v1/encoding/encodings/", encoding_id, "streams"))
+      init_instance(File.join("/v1/encoding/encodings/", encoding_id, "streams"))
       super(hash)
       @outputs = (hsh[:outputs] || []).map { |output| Bitmovin::Encoding::StreamOutput.new(output) }
       @input_streams = (hsh[:input_streams] || []).map { |input| StreamInput.new(@encoding_id, @id, input) }

--- a/lib/bitmovin/resource.rb
+++ b/lib/bitmovin/resource.rb
@@ -22,6 +22,10 @@ module Bitmovin
       end
     end
 
+    def init_instance(path)
+      @instance_resource_path = path
+    end
+
     attr_accessor :id, :name, :description, :created_at, :modified_at
 
 
@@ -34,8 +38,10 @@ module Bitmovin
         raise BitmovinError.new(self), "Cannot save already persisted resource"
       end
 
+      path = @instance_resource_path.nil? ? self.class.resource_path : @instance_resource_path
+
       response = Bitmovin.client.post do |post|
-        post.url self.class.resource_path
+        post.url path
         post.body = collect_attributes
       end
       yield(response.body) if block_given?

--- a/lib/bitmovin/resource.rb
+++ b/lib/bitmovin/resource.rb
@@ -38,10 +38,8 @@ module Bitmovin
         raise BitmovinError.new(self), "Cannot save already persisted resource"
       end
 
-      path = @instance_resource_path.nil? ? self.class.resource_path : @instance_resource_path
-
       response = Bitmovin.client.post do |post|
-        post.url path
+        post.url resource_path
         post.body = collect_attributes
       end
       yield(response.body) if block_given?
@@ -54,7 +52,7 @@ module Bitmovin
     end
 
     def delete!
-      Bitmovin.client.delete File.join(self.class.resource_path, @id)
+      Bitmovin.client.delete File.join(resource_path, @id)
     end
 
     def inspect
@@ -62,6 +60,10 @@ module Bitmovin
     end
 
     private
+
+    def resource_path
+      @instance_resource_path || self.class.resource_path
+    end
 
     def init_from_hash(hash = {})
       hash.each do |name, value|

--- a/spec/bitmovin/encoding/encodings/stream_spec.rb
+++ b/spec/bitmovin/encoding/encodings/stream_spec.rb
@@ -25,6 +25,7 @@ describe Bitmovin::Encoding::Encodings::Stream do
         }
       ],
       id: "a6336204-c929-4a61-b7a0-2cd6665114e9",
+      mode: "STANDARD",
       createQualityMetaData: true,
       createdAt: "2016-06-25T20:09:23.69Z",
       modifiedAt: "2016-06-25T20:09:23.69Z"


### PR DESCRIPTION
This fix this situation:
```ruby
>> s1 = Bitmovin::Encoding::Encodings::Stream.new("encoding1")
Bitmovin::Encoding::Encodings::Stream(id: , name: )
>> s2 = Bitmovin::Encoding::Encodings::Stream.new("encoding2")
Bitmovin::Encoding::Encodings::Stream(id: , name: )
>> s1.class.instance_variable_get(:@resource_path)
"/v1/encoding/encodings/encoding2/streams"
>> s2.class.instance_variable_get(:@resource_path)
"/v1/encoding/encodings/encoding2/streams"
```
To this:
```ruby
>> s1 = Bitmovin::Encoding::Encodings::Stream.new("encoding1")
Bitmovin::Encoding::Encodings::Stream(id: , name: )
>> s2 = Bitmovin::Encoding::Encodings::Stream.new("encoding2")
Bitmovin::Encoding::Encodings::Stream(id: , name: )
>> s1.instance_variable_get(:@instance_resource_path)
"/v1/encoding/encodings/encoding1/streams"
>> s2.instance_variable_get(:@instance_resource_path)
"/v1/encoding/encodings/encoding2/streams"
```