### PR TITLE
Fix nested cammelCase transformation

### DIFF
--- a/lib/bitmovin/resource.rb
+++ b/lib/bitmovin/resource.rb
@@ -71,26 +71,22 @@ module Bitmovin
     end
 
     def collect_attributes
-      val = Hash.new
       ignored_variables = []
       if (self.respond_to?(:ignore_fields))
         ignored_variables = self.ignore_fields
       end
       ignored_variables.push(:@instance_resource_path)
-
-      instance_variables.each do |name|
-        if ignored_variables.include?(name)
-          next
-        end
-
-        if name == :@max_ctu_size
-          val['maxCTUSize'] = instance_variable_get(name)
+      attributes_value = instance_variables.inject({}) do |result, item|
+        if ignored_variables.include?(item)
+          result
         else
-          json_name = ActiveSupport::Inflector.camelize(name.to_s.gsub(/@/, ''), false)
-          val[json_name] = instance_variable_get(name)
+          name = item == :@max_ctu_size ? 'maxCTUSize' : item.to_s.gsub(/@/, '')
+          result.merge(
+            name => instance_variable_get(item)
+          )
         end
       end
-      val
+      camelize_hash(attributes_value)
     end
   end
 end


### PR DESCRIPTION
When you need to use param with hash value, for example:

```
params = {
  max_average_light_level: 100,
  color_config: {
    color_space: 'blah'
  }
}

```

The sent param was:
```
{
  maxAverageLightLevel: 100,
  colorConfig: {
    color_space: 'blah'
  }
}

```

The nested color_space param was not camelized.

With these changes the result is:
```
{
  maxAverageLightLevel: 100,
  colorConfig: {
    colorSpace: 'blah'
  }
}

```
